### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/provisioning-service.spec
+++ b/rpm/provisioning-service.spec
@@ -1,15 +1,15 @@
 Name:       provisioning-service
 Summary:    OTA provisioning service
-Version:    0.1.4
+Version:    0.1.7
 Release:    1
 License:    GPLv2
-URL:        https://git.merproject.org/mer-core/provisioning-service
+URL:        https://github.com/sailfishos/provisioning-service
 Source0:    %{name}-%{version}.tar.bz2
 BuildRequires:  pkgconfig(glib-2.0)
 BuildRequires:  pkgconfig(libwbxml2) >= 0.11.6
 BuildRequires:  pkgconfig(libgofono) >= 2.0.5
 BuildRequires:  pkgconfig(libglibutil)
-BuildRequires:  systemd
+BuildRequires:  pkgconfig(systemd)
 Requires:  libgofono >= 2.0.5
 Requires:  ofono
 Requires:  sailfish-setup


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.